### PR TITLE
Configure Railway domain support and Swagger for production

### DIFF
--- a/src/services/Integration.Api/Controllers/HealthController.cs
+++ b/src/services/Integration.Api/Controllers/HealthController.cs
@@ -7,6 +7,17 @@ namespace Integration.Api.Controllers
     public class HealthController : ControllerBase
     {
         /// <summary>
+        /// Redireciona para o Swagger quando acessar a raiz da API
+        /// </summary>
+        /// <returns>Redirecionamento para Swagger</returns>
+        [HttpGet("/")]
+        [AllowAnonymous]
+        public IActionResult Root()
+        {
+            return Redirect("/swagger");
+        }
+
+        /// <summary>
         /// Health check endpoint para Railway
         /// </summary>
         /// <returns>Status da API</returns>
@@ -16,13 +27,16 @@ namespace Integration.Api.Controllers
         [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
         public IActionResult Health()
         {
+            var domain = HttpContext.Request.Host.ToString();
             return Ok(new
             {
                 status = "healthy",
                 timestamp = DateTime.UtcNow,
                 version = "1.0.0",
                 environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Development",
-                port = Environment.GetEnvironmentVariable("PORT") ?? "80"
+                port = Environment.GetEnvironmentVariable("PORT") ?? "80",
+                domain = domain,
+                swaggerUrl = $"{(HttpContext.Request.IsHttps ? "https" : "http")}://{domain}/swagger"
             });
         }
 

--- a/src/services/Integration.Api/Program.cs
+++ b/src/services/Integration.Api/Program.cs
@@ -40,6 +40,12 @@ namespace Integration.Api
                 serverOptions.ListenAnyIP(int.Parse(port));
             });
 
+            // Configure URLs for Railway domain
+            if (builder.Environment.IsProduction())
+            {
+                builder.WebHost.UseUrls($"http://0.0.0.0:{port}");
+            }
+
             // Railway-specific logging
             builder.Logging.ClearProviders();
             builder.Logging.AddConsole();
@@ -47,6 +53,15 @@ namespace Integration.Api
 
             // Add health checks for Railway
             builder.Services.AddHealthChecks();
+            
+            // Configure forwarded headers for Railway proxy
+            builder.Services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor | 
+                                         Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto;
+                options.KnownNetworks.Clear();
+                options.KnownProxies.Clear();
+            });
         }
 
         private static async Task RunMigrationsAsync(WebApplication app)


### PR DESCRIPTION
- Add Railway domain to CORS whitelist
- Configure Swagger servers for Railway domain odontosmileconectaapi-production.up.railway.app
- Add forwarded headers support for Railway proxy
- Enhance HealthController with root redirect to Swagger
- Update production CORS policies for Railway deployment